### PR TITLE
Fix warnings for vike config and cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "server": "vite dev",
-    "build": "vite build",
+    "server": "vike dev",
+    "build": "vike build",
     "predeploy": "make build",
     "deploy": "gh-pages -d dist",
     "test": "vitest",

--- a/src/pages/+config.ts
+++ b/src/pages/+config.ts
@@ -2,4 +2,5 @@ import vikeReact from "vike-react/config";
 
 export default {
   extends: [vikeReact],
+  prerender: true,
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,9 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import vike from "vike/plugin";
 
 export default defineConfig({
   base: "/",
-  plugins: [react(), vike({ prerender: true })],
+  plugins: [react()],
   ssr: {
     noExternal: [/^d3.*$/, /^@nivo.*$/],
   },


### PR DESCRIPTION
```
21:24:34 [vike][Warning] Define Vike settings in +config.js instead of vite.config.js https://vike.dev/migration/settings
21:24:34 [vike][Warning] Vite's CLI is deprecated https://vike.dev/migration/cli
```