### PR TITLE
電気使用量の月別保存形式に変更

### DIFF
--- a/web/src/hooks/useLocalStorage.test.tsx
+++ b/web/src/hooks/useLocalStorage.test.tsx
@@ -1,0 +1,35 @@
+import { renderHook, act } from "@testing-library/react";
+import { expect, test, describe, beforeEach } from "vitest";
+import useLocalStorage from "@/hooks/useLocalStorage";
+
+describe("useLocalStorage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test("initializes from localStorage", () => {
+    localStorage.setItem("ls-key", "1");
+    const { result } = renderHook(() => useLocalStorage<number>("ls-key", 0));
+    expect(result.current[0]).toBe(1);
+  });
+
+  test("updates localStorage when value changes", () => {
+    const { result } = renderHook(() => useLocalStorage<number>("ls-key", 0));
+    act(() => {
+      const [, setValue] = result.current;
+      setValue(5);
+    });
+    expect(localStorage.getItem("ls-key")).toBe("5");
+  });
+
+  test("stores object values", () => {
+    const { result } = renderHook(() =>
+      useLocalStorage<Record<string, number>>("ls-obj", { a: 1 }),
+    );
+    act(() => {
+      const [, setValue] = result.current;
+      setValue((prev) => ({ ...prev, b: 2 }));
+    });
+    expect(localStorage.getItem("ls-obj")).toBe(JSON.stringify({ a: 1, b: 2 }));
+  });
+});

--- a/web/src/hooks/useLocalStorage.ts
+++ b/web/src/hooks/useLocalStorage.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from "react";
+
+function useLocalStorage<T>(
+  key: string,
+  initialValue: T,
+): [T, React.Dispatch<React.SetStateAction<T>>] {
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    if (typeof window === "undefined") return initialValue;
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? (JSON.parse(item) as T) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      try {
+        window.localStorage.setItem(key, JSON.stringify(storedValue));
+      } catch {
+        // ignore write errors
+      }
+    }
+  }, [key, storedValue]);
+
+  return [storedValue, setStoredValue];
+}
+
+export default useLocalStorage;


### PR DESCRIPTION
## 変更内容
- `useLocalStorage` のテストにオブジェクト保存のケースを追加
- 電気料金比較ページの使用量を月ごとのマッピングで保存するよう更新

## テスト結果
- `make lint`
- `make test`

## ラベル
AI_Codex

------
https://chatgpt.com/codex/tasks/task_e_684291bdd2a08332b30b1c0800c0c675