### PR TITLE
ZIO HTTP サーバーの実装追加

### DIFF
--- a/backend/build.sbt
+++ b/backend/build.sbt
@@ -3,5 +3,7 @@ version := "0.1.0"
 scalaVersion := "3.7.1"
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.19" % Test
+  "org.scalatest" %% "scalatest" % "3.2.19" % Test,
+  "dev.zio" %% "zio" % "2.1.19",
+  "dev.zio" %% "zio-http" % "3.3.3"
 )

--- a/backend/src/main/scala/io/github/ara_ta3/Main.scala
+++ b/backend/src/main/scala/io/github/ara_ta3/Main.scala
@@ -1,5 +1,12 @@
 package io.github.ara_ta3
 
-object Main:
-  @main def run(): Unit =
-    println("Hello, Scala backend!")
+import zio._
+import zio.http._
+
+object Main extends ZIOAppDefault:
+  private val route =
+    Method.GET / Root -> handler(Response.json("""{"hello":"world"}"""))
+
+  private val app = Routes(route)
+
+  override val run = Server.serve(app).provide(Server.default)


### PR DESCRIPTION
バックエンドでZIO HTTPを使ったサーバーを実装しました。`GET /` で `{"hello":"world"}` をJSON形式で返します。

------
https://chatgpt.com/codex/tasks/task_e_6843fbc80c6c8332b5842da1af1697a3