### PR TITLE
リダイレクトページにcanonicalを追加

### DIFF
--- a/frontend/resources/cat/calorie/food/1/index.html
+++ b/frontend/resources/cat/calorie/food/1/index.html
@@ -7,6 +7,7 @@
       http-equiv="refresh"
       content="0;url=https://nekometry.web.app/calorie/food/1/"
     />
+    <link rel="canonical" href="https://nekometry.web.app/calorie/food/1/">
   </head>
   <body>
     <p>

--- a/frontend/resources/cat/calorie/food/10/index.html
+++ b/frontend/resources/cat/calorie/food/10/index.html
@@ -7,6 +7,7 @@
       http-equiv="refresh"
       content="0;url=https://nekometry.web.app/calorie/food/10/"
     />
+    <link rel="canonical" href="https://nekometry.web.app/calorie/food/10/">
   </head>
   <body>
     <p>

--- a/frontend/resources/cat/calorie/food/2/index.html
+++ b/frontend/resources/cat/calorie/food/2/index.html
@@ -7,6 +7,7 @@
       http-equiv="refresh"
       content="0;url=https://nekometry.web.app/calorie/food/2/"
     />
+    <link rel="canonical" href="https://nekometry.web.app/calorie/food/2/">
   </head>
   <body>
     <p>

--- a/frontend/resources/cat/calorie/food/3/index.html
+++ b/frontend/resources/cat/calorie/food/3/index.html
@@ -7,6 +7,7 @@
       http-equiv="refresh"
       content="0;url=https://nekometry.web.app/calorie/food/3/"
     />
+    <link rel="canonical" href="https://nekometry.web.app/calorie/food/3/">
   </head>
   <body>
     <p>

--- a/frontend/resources/cat/calorie/food/4/index.html
+++ b/frontend/resources/cat/calorie/food/4/index.html
@@ -7,6 +7,7 @@
       http-equiv="refresh"
       content="0;url=https://nekometry.web.app/calorie/food/4/"
     />
+    <link rel="canonical" href="https://nekometry.web.app/calorie/food/4/">
   </head>
   <body>
     <p>

--- a/frontend/resources/cat/calorie/food/5/index.html
+++ b/frontend/resources/cat/calorie/food/5/index.html
@@ -7,6 +7,7 @@
       http-equiv="refresh"
       content="0;url=https://nekometry.web.app/calorie/food/5/"
     />
+    <link rel="canonical" href="https://nekometry.web.app/calorie/food/5/">
   </head>
   <body>
     <p>

--- a/frontend/resources/cat/calorie/food/6/index.html
+++ b/frontend/resources/cat/calorie/food/6/index.html
@@ -7,6 +7,7 @@
       http-equiv="refresh"
       content="0;url=https://nekometry.web.app/calorie/food/6/"
     />
+    <link rel="canonical" href="https://nekometry.web.app/calorie/food/6/">
   </head>
   <body>
     <p>

--- a/frontend/resources/cat/calorie/food/7/index.html
+++ b/frontend/resources/cat/calorie/food/7/index.html
@@ -7,6 +7,7 @@
       http-equiv="refresh"
       content="0;url=https://nekometry.web.app/calorie/food/7/"
     />
+    <link rel="canonical" href="https://nekometry.web.app/calorie/food/7/">
   </head>
   <body>
     <p>

--- a/frontend/resources/cat/calorie/food/8/index.html
+++ b/frontend/resources/cat/calorie/food/8/index.html
@@ -7,6 +7,7 @@
       http-equiv="refresh"
       content="0;url=https://nekometry.web.app/calorie/food/8/"
     />
+    <link rel="canonical" href="https://nekometry.web.app/calorie/food/8/">
   </head>
   <body>
     <p>

--- a/frontend/resources/cat/calorie/food/9/index.html
+++ b/frontend/resources/cat/calorie/food/9/index.html
@@ -7,6 +7,7 @@
       http-equiv="refresh"
       content="0;url=https://nekometry.web.app/calorie/food/9/"
     />
+    <link rel="canonical" href="https://nekometry.web.app/calorie/food/9/">
   </head>
   <body>
     <p>

--- a/frontend/resources/cat/calorie/foods/index.html
+++ b/frontend/resources/cat/calorie/foods/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>リダイレクト中 - 対応フード一覧</title>
     <meta http-equiv="refresh" content="0;url=https://nekometry.web.app/calorie/foods/">
+    <link rel="canonical" href="https://nekometry.web.app/calorie/foods/">
 </head>
 <body>
     <p>ページが自動的にリダイレクトされない場合は、<a href="https://nekometry.web.app/calorie/foods/">こちらをクリック</a>してください。</p>

--- a/frontend/resources/cat/calorie/index.html
+++ b/frontend/resources/cat/calorie/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>リダイレクト中 - 猫のカロリー計算</title>
     <meta http-equiv="refresh" content="0;url=https://nekometry.web.app/">
+    <link rel="canonical" href="https://nekometry.web.app/">
 </head>
 <body>
     <p>ページが自動的にリダイレクトされない場合は、<a href="https://nekometry.web.app/">こちらをクリック</a>してください。</p>

--- a/frontend/resources/cat/calorie/reference/index.html
+++ b/frontend/resources/cat/calorie/reference/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>リダイレクト中 - 参考文献</title>
     <meta http-equiv="refresh" content="0;url=https://nekometry.web.app/calorie/reference/">
+    <link rel="canonical" href="https://nekometry.web.app/calorie/reference/">
 </head>
 <body>
     <p>ページが自動的にリダイレクトされない場合は、<a href="https://nekometry.web.app/calorie/reference/">こちらをクリック</a>してください。</p>

--- a/frontend/resources/cat/calorie/transition/index.html
+++ b/frontend/resources/cat/calorie/transition/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>リダイレクト中 - フード切り替えプラン</title>
     <meta http-equiv="refresh" content="0;url=https://nekometry.web.app/calorie/transition/">
+    <link rel="canonical" href="https://nekometry.web.app/calorie/transition/">
 </head>
 <body>
     <p>ページが自動的にリダイレクトされない場合は、<a href="https://nekometry.web.app/calorie/transition/">こちらをクリック</a>してください。</p>


### PR DESCRIPTION
## 概要
resources ディレクトリ配下のリダイレクト用 HTML に canonical 設定を追加しました。

## 変更点
- meta refresh で指定している URL を `<link rel="canonical">` として追記

## テスト
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6848109cfaa4833284399c7fabbb471a