### PR TITLE
プロジェクト公開ページへの導線を統一する

### DIFF
--- a/frontend/src/components/project/DemoButton.tsx
+++ b/frontend/src/components/project/DemoButton.tsx
@@ -2,13 +2,9 @@ import React from "react";
 
 interface DemoButtonProps {
   demoUrl?: string;
-  buttonText?: string;
 }
 
-const DemoButton: React.FC<DemoButtonProps> = ({
-  demoUrl,
-  buttonText = "View Demo",
-}) => {
+const DemoButton: React.FC<DemoButtonProps> = ({ demoUrl }) => {
   if (!demoUrl) return null;
 
   return (
@@ -23,7 +19,7 @@ const DemoButton: React.FC<DemoButtonProps> = ({
           rel="noopener noreferrer"
           className="flex cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-primary-700 text-white text-sm font-bold leading-normal hover:bg-primary-500 transition-colors"
         >
-          <span className="truncate">{buttonText}</span>
+          <span className="truncate">公開ページを見る</span>
         </a>
       </div>
     </div>

--- a/frontend/src/components/project/ProjectCard.tsx
+++ b/frontend/src/components/project/ProjectCard.tsx
@@ -52,9 +52,9 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
   showActions = true,
 }) => {
   return (
-    <div className="bg-white border border-secondary-100 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200">
+    <div className="flex h-full flex-col bg-white border border-secondary-100 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200">
       <ProjectCardImage project={project} />
-      <div className="p-6">
+      <div className="flex flex-1 flex-col p-6">
         <h2 className="text-xl font-bold text-primary-700 mb-2">
           {project.title}
         </h2>
@@ -79,7 +79,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
         )}
 
         {showActions && (
-          <div className="flex justify-between items-center">
+          <div className="mt-auto flex items-center justify-between gap-4">
             <a
               href={`/projects/${project.id}`}
               className="inline-flex items-center p-2 text-sm font-medium text-center text-white bg-primary-900 rounded-lg hover:bg-primary-700 focus:ring-4 focus:outline-none focus:ring-primary-300 transition-colors"
@@ -108,7 +108,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
                 rel="noopener noreferrer"
                 className="text-primary-700 hover:text-primary-900 text-sm font-medium"
               >
-                {project.buttonText || "Demo"}
+                公開ページを見る
               </a>
             )}
           </div>

--- a/frontend/src/data/projects.ts
+++ b/frontend/src/data/projects.ts
@@ -21,7 +21,6 @@ export const projects: Project[] = [
     ],
     imageUrl: Appricity as string,
     demoUrl: "https://appricity.vercel.app/",
-    buttonText: "サービスを見る",
   },
   {
     id: "nekometry",
@@ -48,7 +47,6 @@ export const projects: Project[] = [
     ],
     imageUrl: Nekometry as string,
     demoUrl: "https://nekometry.web.app/",
-    buttonText: "ツールを使う",
   },
   {
     id: "personal-website",
@@ -70,7 +68,5 @@ export const projects: Project[] = [
       { label: "Hosting", value: "GitHub Pages" },
       { label: "CI/CD", value: "GitHub Actions" },
     ],
-    demoUrl: "https://ara-ta3.github.io",
-    buttonText: "サイトを見る",
   },
 ];

--- a/frontend/src/pages/index/__snapshots__/Page.test.tsx.snap
+++ b/frontend/src/pages/index/__snapshots__/Page.test.tsx.snap
@@ -202,7 +202,7 @@ exports[`Home Snapshot Test > render Home 1`] = `
               class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4"
             >
               <div
-                class="bg-white border border-secondary-100 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200"
+                class="flex h-full flex-col bg-white border border-secondary-100 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200"
               >
                 <div
                   class="h-48 border-b border-secondary-100 rounded-t-lg overflow-hidden bg-secondary-50"
@@ -214,7 +214,7 @@ exports[`Home Snapshot Test > render Home 1`] = `
                   />
                 </div>
                 <div
-                  class="p-6"
+                  class="flex flex-1 flex-col p-6"
                 >
                   <h2
                     class="text-xl font-bold text-primary-700 mb-2"
@@ -251,7 +251,7 @@ exports[`Home Snapshot Test > render Home 1`] = `
                     </span>
                   </div>
                   <div
-                    class="flex justify-between items-center"
+                    class="mt-auto flex items-center justify-between gap-4"
                   >
                     <a
                       class="inline-flex items-center p-2 text-sm font-medium text-center text-white bg-primary-900 rounded-lg hover:bg-primary-700 focus:ring-4 focus:outline-none focus:ring-primary-300 transition-colors"
@@ -280,13 +280,13 @@ exports[`Home Snapshot Test > render Home 1`] = `
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      サービスを見る
+                      公開ページを見る
                     </a>
                   </div>
                 </div>
               </div>
               <div
-                class="bg-white border border-secondary-100 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200"
+                class="flex h-full flex-col bg-white border border-secondary-100 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200"
               >
                 <div
                   class="h-48 border-b border-secondary-100 rounded-t-lg overflow-hidden bg-secondary-50"
@@ -298,7 +298,7 @@ exports[`Home Snapshot Test > render Home 1`] = `
                   />
                 </div>
                 <div
-                  class="p-6"
+                  class="flex flex-1 flex-col p-6"
                 >
                   <h2
                     class="text-xl font-bold text-primary-700 mb-2"
@@ -335,7 +335,7 @@ exports[`Home Snapshot Test > render Home 1`] = `
                     </span>
                   </div>
                   <div
-                    class="flex justify-between items-center"
+                    class="mt-auto flex items-center justify-between gap-4"
                   >
                     <a
                       class="inline-flex items-center p-2 text-sm font-medium text-center text-white bg-primary-900 rounded-lg hover:bg-primary-700 focus:ring-4 focus:outline-none focus:ring-primary-300 transition-colors"
@@ -364,7 +364,7 @@ exports[`Home Snapshot Test > render Home 1`] = `
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      ツールを使う
+                      公開ページを見る
                     </a>
                   </div>
                 </div>

--- a/frontend/src/pages/projects/@id/+Page.tsx
+++ b/frontend/src/pages/projects/@id/+Page.tsx
@@ -22,7 +22,7 @@ const ProjectDetailPage: React.FC = () => {
       <TechnologiesSection technologies={project.technologies} />
       <ProjectDetails details={project.details} />
       <ScreenshotGallery imageUrl={project.imageUrl} />
-      <DemoButton demoUrl={project.demoUrl} buttonText={project.buttonText} />
+      <DemoButton demoUrl={project.demoUrl} />
     </>
   );
 };

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -12,5 +12,4 @@ export interface Project {
   details: ProjectDetail[];
   imageUrl?: string;
   demoUrl?: string;
-  buttonText?: string;
 }


### PR DESCRIPTION
## issues

関連するissueはありません。

## 概要

プロジェクト一覧と詳細ページの公開ページへのリンク文言を「公開ページを見る」に統一しました。
あわせて、プロジェクトカードのボタン位置を揃え、不要になった `buttonText` プロパティを削除しました。

## 関連リンク

特にありません。

## Testing

未実施（依頼されていないため）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **変更**
  - プロジェクトカードと詳細ページの公開ページボタンの表示文言を「公開ページを見る」に統一しました。
  - プロジェクトごとに個別のボタン文言を設定する仕様を廃止しました。
  - プロジェクトカードのレイアウトとアクション領域の配置・余白を調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->