### PR TITLE
Splatoon 3の記録ページを追加

### DIFF
--- a/frontend/resources/sitemap.xml
+++ b/frontend/resources/sitemap.xml
@@ -39,4 +39,7 @@
     <url>
         <loc>https://ara-ta3.github.io/hobbies</loc>
     </url>
+    <url>
+        <loc>https://ara-ta3.github.io/hobbies/splatoon</loc>
+    </url>
 </urlset>

--- a/frontend/resources/sitemap.xml
+++ b/frontend/resources/sitemap.xml
@@ -36,4 +36,7 @@
     <url>
         <loc>https://ara-ta3.github.io/slides</loc>
     </url>
+    <url>
+        <loc>https://ara-ta3.github.io/hobbies</loc>
+    </url>
 </urlset>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -7,7 +7,7 @@ const HeaderMenuItem: React.FC<{ href: string; children: string }> = ({
 }) => {
   return (
     <a
-      className="text-primary-500 hover:text-primary-700 text-sm font-medium leading-normal"
+      className="whitespace-nowrap text-xs font-medium leading-normal text-primary-500 hover:text-primary-700 sm:text-sm"
       href={href}
     >
       {children}
@@ -17,21 +17,22 @@ const HeaderMenuItem: React.FC<{ href: string; children: string }> = ({
 
 const Header: React.FC = () => {
   return (
-    <header className="flex items-center justify-between border-b border-solid border-gray-200 px-8 py-4 sticky top-0 z-50 bg-white">
+    <header className="sticky top-0 z-50 flex items-center justify-between border-b border-solid border-gray-200 bg-white px-4 py-4 sm:px-8">
       <div className="flex items-center gap-4 ">
         <a href="/">
           <img
             src={Logo}
             alt="Logo"
-            className="w-24 hover:opacity-80 transition-opacity"
+            className="w-16 transition-opacity hover:opacity-80 sm:w-24"
           />
         </a>
       </div>
       <div className="flex flex-1 justify-end gap-8">
-        <div className="flex items-center gap-9">
+        <div className="flex items-center gap-4 sm:gap-9">
           <HeaderMenuItem href="/projects">個人開発</HeaderMenuItem>
           <HeaderMenuItem href="/articles">記事一覧</HeaderMenuItem>
           <HeaderMenuItem href="/slides">スライド</HeaderMenuItem>
+          <HeaderMenuItem href="/hobbies">趣味</HeaderMenuItem>
         </div>
       </div>
     </header>

--- a/frontend/src/components/__snapshots__/Header.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Header.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Header Snapshot Test > render headers 1`] = `
 <DocumentFragment>
   <header
-    class="flex items-center justify-between border-b border-solid border-gray-200 px-8 py-4 sticky top-0 z-50 bg-white"
+    class="sticky top-0 z-50 flex items-center justify-between border-b border-solid border-gray-200 bg-white px-4 py-4 sm:px-8"
   >
     <div
       class="flex items-center gap-4 "
@@ -13,7 +13,7 @@ exports[`Header Snapshot Test > render headers 1`] = `
       >
         <img
           alt="Logo"
-          class="w-24 hover:opacity-80 transition-opacity"
+          class="w-16 transition-opacity hover:opacity-80 sm:w-24"
           src="/src/assets/images/logo.png"
         />
       </a>
@@ -22,25 +22,31 @@ exports[`Header Snapshot Test > render headers 1`] = `
       class="flex flex-1 justify-end gap-8"
     >
       <div
-        class="flex items-center gap-9"
+        class="flex items-center gap-4 sm:gap-9"
       >
         <a
-          class="text-primary-500 hover:text-primary-700 text-sm font-medium leading-normal"
+          class="whitespace-nowrap text-xs font-medium leading-normal text-primary-500 hover:text-primary-700 sm:text-sm"
           href="/projects"
         >
           個人開発
         </a>
         <a
-          class="text-primary-500 hover:text-primary-700 text-sm font-medium leading-normal"
+          class="whitespace-nowrap text-xs font-medium leading-normal text-primary-500 hover:text-primary-700 sm:text-sm"
           href="/articles"
         >
           記事一覧
         </a>
         <a
-          class="text-primary-500 hover:text-primary-700 text-sm font-medium leading-normal"
+          class="whitespace-nowrap text-xs font-medium leading-normal text-primary-500 hover:text-primary-700 sm:text-sm"
           href="/slides"
         >
           スライド
+        </a>
+        <a
+          class="whitespace-nowrap text-xs font-medium leading-normal text-primary-500 hover:text-primary-700 sm:text-sm"
+          href="/hobbies"
+        >
+          趣味
         </a>
       </div>
     </div>

--- a/frontend/src/components/hobbies/SplatoonHighlights.test.tsx
+++ b/frontend/src/components/hobbies/SplatoonHighlights.test.tsx
@@ -2,11 +2,11 @@ import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import SplatoonHighlights from "@/components/hobbies/SplatoonHighlights";
-import { splatoonSeasonRecords } from "@/data/splatoon";
 import {
   buildSplatoonXpSummary,
   getBestSplatoonRank,
 } from "@/domains/hobbies/splatoon";
+import { splatoonSeasonRecords } from "@/data/splatoon";
 
 describe("SplatoonHighlights", () => {
   it("初期表示では通算を選択し、ルール別の歴代最高XPを表示する", () => {

--- a/frontend/src/components/hobbies/SplatoonHighlights.test.tsx
+++ b/frontend/src/components/hobbies/SplatoonHighlights.test.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import SplatoonHighlights from "@/components/hobbies/SplatoonHighlights";
+import { splatoonSeasonRecords } from "@/data/splatoon";
+import {
+  buildSplatoonXpSummary,
+  getBestSplatoonRank,
+} from "@/domains/hobbies/splatoon";
+
+describe("SplatoonHighlights", () => {
+  it("初期表示では通算を選択し、ルール別の歴代最高XPを表示する", () => {
+    render(
+      <SplatoonHighlights
+        bestRank={getBestSplatoonRank(splatoonSeasonRecords)}
+        xpSummary={buildSplatoonXpSummary(splatoonSeasonRecords)}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "通算" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "2025" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(
+      screen.getAllByRole("button").map((button) => button.textContent),
+    ).toEqual(["通算", "2022", "2023", "2024", "2025", "2026"]);
+    expect(screen.getByText("2566.0")).toBeInTheDocument();
+    expect(screen.getByText("2630.1")).toBeInTheDocument();
+    expect(screen.getByText("2565.3")).toBeInTheDocument();
+    expect(screen.getByText("2615.2")).toBeInTheDocument();
+  });
+
+  it("2025年を選択すると選択状態とルール別最高XPを切り替える", () => {
+    render(
+      <SplatoonHighlights
+        bestRank={getBestSplatoonRank(splatoonSeasonRecords)}
+        xpSummary={buildSplatoonXpSummary(splatoonSeasonRecords)}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "2025" }));
+
+    expect(screen.getByRole("button", { name: "通算" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(screen.getByRole("button", { name: "2025" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByText("2447.2")).toBeInTheDocument();
+    expect(screen.getByText("2471.6")).toBeInTheDocument();
+    expect(screen.getByText("2452.5")).toBeInTheDocument();
+    expect(screen.getByText("2564.1")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/hobbies/SplatoonHighlights.tsx
+++ b/frontend/src/components/hobbies/SplatoonHighlights.tsx
@@ -1,32 +1,89 @@
-import React from "react";
-import type { SplatoonHighlights as Highlights } from "@/domains/hobbies/splatoon";
-import { splatoonRuleLabels } from "@/domains/hobbies/splatoon";
+import React, { useState } from "react";
+import type {
+  SplatoonHighlight,
+  SplatoonXpSummary,
+} from "@/domains/hobbies/splatoon";
+import { splatoonRuleLabels, splatoonRules } from "@/domains/hobbies/splatoon";
 
 type Props = {
-  highlights: Highlights;
+  xpSummary: SplatoonXpSummary;
+  bestRank: SplatoonHighlight;
 };
 
-const SplatoonHighlights: React.FC<Props> = ({ highlights }) => {
+type SelectedPeriod = "all" | number;
+
+const SplatoonHighlights: React.FC<Props> = ({ xpSummary, bestRank }) => {
+  const [selectedPeriod, setSelectedPeriod] = useState<SelectedPeriod>("all");
+  const selectedHighestXp =
+    selectedPeriod === "all"
+      ? xpSummary.allTime
+      : (xpSummary.yearly.find(({ year }) => year === selectedPeriod)
+          ?.highestXpByRule ?? xpSummary.allTime);
+
   return (
-    <div className="mb-10 grid gap-4 sm:grid-cols-2">
-      <section className="rounded-xl border border-primary-100 bg-primary-50 p-5">
-        <p className="text-sm font-semibold text-primary-600">歴代最高XP</p>
-        <p className="mt-2 text-3xl font-bold text-primary-900">
-          {highlights.highestXp.value.toFixed(1)}
-        </p>
-        <p className="mt-2 text-sm text-secondary-600">
-          {highlights.highestXp.season}・
-          {splatoonRuleLabels[highlights.highestXp.rule]}
-        </p>
+    <div className="mb-10 space-y-6">
+      <section>
+        <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <h3 className="text-2xl font-semibold text-primary-900">
+            ルール別最高XP
+          </h3>
+          <div className="flex flex-wrap gap-2">
+            <button
+              aria-pressed={selectedPeriod === "all"}
+              className={`rounded-md px-3 py-2 text-sm font-semibold transition-colors ${
+                selectedPeriod === "all"
+                  ? "bg-primary-600 text-white"
+                  : "border border-secondary-200 bg-white text-secondary-700 hover:bg-secondary-50"
+              }`}
+              onClick={() => setSelectedPeriod("all")}
+              type="button"
+            >
+              通算
+            </button>
+            {xpSummary.yearly.map(({ year }) => (
+              <button
+                aria-pressed={selectedPeriod === year}
+                className={`rounded-md px-3 py-2 text-sm font-semibold transition-colors ${
+                  selectedPeriod === year
+                    ? "bg-primary-600 text-white"
+                    : "border border-secondary-200 bg-white text-secondary-700 hover:bg-secondary-50"
+                }`}
+                key={year}
+                onClick={() => setSelectedPeriod(year)}
+                type="button"
+              >
+                {year}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {splatoonRules.map((rule) => (
+            <div
+              className="rounded-xl border border-primary-100 bg-primary-50 p-5"
+              key={rule}
+            >
+              <p className="text-sm font-semibold text-primary-600">
+                {splatoonRuleLabels[rule]}
+              </p>
+              <p className="mt-2 text-3xl font-bold text-primary-900">
+                {selectedHighestXp[rule].value.toFixed(1)}
+              </p>
+              <p className="mt-2 text-sm text-secondary-600">
+                {selectedHighestXp[rule].season}
+              </p>
+            </div>
+          ))}
+        </div>
       </section>
+
       <section className="rounded-xl border border-secondary-200 bg-secondary-50 p-5">
         <p className="text-sm font-semibold text-secondary-600">歴代最高順位</p>
         <p className="mt-2 text-3xl font-bold text-secondary-900">
-          {highlights.bestRank.value.toLocaleString("ja-JP")}位
+          {bestRank.value.toLocaleString("ja-JP")}位
         </p>
         <p className="mt-2 text-sm text-secondary-600">
-          {highlights.bestRank.season}・
-          {splatoonRuleLabels[highlights.bestRank.rule]}
+          {bestRank.season}・{splatoonRuleLabels[bestRank.rule]}
         </p>
       </section>
     </div>

--- a/frontend/src/components/hobbies/SplatoonHighlights.tsx
+++ b/frontend/src/components/hobbies/SplatoonHighlights.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import type { SplatoonHighlights as Highlights } from "@/domains/hobbies/splatoon";
+import { splatoonRuleLabels } from "@/domains/hobbies/splatoon";
+
+type Props = {
+  highlights: Highlights;
+};
+
+const SplatoonHighlights: React.FC<Props> = ({ highlights }) => {
+  return (
+    <div className="mb-10 grid gap-4 sm:grid-cols-2">
+      <section className="rounded-xl border border-primary-100 bg-primary-50 p-5">
+        <p className="text-sm font-semibold text-primary-600">歴代最高XP</p>
+        <p className="mt-2 text-3xl font-bold text-primary-900">
+          {highlights.highestXp.value.toFixed(1)}
+        </p>
+        <p className="mt-2 text-sm text-secondary-600">
+          {highlights.highestXp.season}・
+          {splatoonRuleLabels[highlights.highestXp.rule]}
+        </p>
+      </section>
+      <section className="rounded-xl border border-secondary-200 bg-secondary-50 p-5">
+        <p className="text-sm font-semibold text-secondary-600">歴代最高順位</p>
+        <p className="mt-2 text-3xl font-bold text-secondary-900">
+          {highlights.bestRank.value.toLocaleString("ja-JP")}位
+        </p>
+        <p className="mt-2 text-sm text-secondary-600">
+          {highlights.bestRank.season}・
+          {splatoonRuleLabels[highlights.bestRank.rule]}
+        </p>
+      </section>
+    </div>
+  );
+};
+
+export default SplatoonHighlights;

--- a/frontend/src/components/hobbies/SplatoonRecordsTable.tsx
+++ b/frontend/src/components/hobbies/SplatoonRecordsTable.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import type { SplatoonSeasonRecord } from "@/domains/hobbies/splatoon";
+import { splatoonRuleLabels, splatoonRules } from "@/domains/hobbies/splatoon";
+
+type Props = {
+  records: readonly SplatoonSeasonRecord[];
+};
+
+const SplatoonRecordsTable: React.FC<Props> = ({ records }) => {
+  return (
+    <section>
+      <h2 className="mb-4 text-2xl font-semibold text-primary-900">
+        シーズン別記録
+      </h2>
+      <div className="overflow-x-auto rounded-lg border border-secondary-200">
+        <table className="min-w-[1080px] border-collapse bg-white text-sm">
+          <thead>
+            <tr className="bg-primary-50 text-primary-900">
+              <th
+                className="border-b border-r border-secondary-200 px-4 py-3 text-left"
+                rowSpan={2}
+              >
+                シーズン名
+              </th>
+              {splatoonRules.map((rule) => (
+                <th
+                  className="border-b border-r border-secondary-200 px-4 py-3 text-center last:border-r-0"
+                  colSpan={2}
+                  key={rule}
+                >
+                  {splatoonRuleLabels[rule]}
+                </th>
+              ))}
+            </tr>
+            <tr className="bg-primary-50 text-primary-900">
+              {splatoonRules.flatMap((rule) => [
+                <th
+                  className="border-b border-r border-secondary-200 px-4 py-2 text-right"
+                  key={`${rule}-xp`}
+                >
+                  XP
+                </th>,
+                <th
+                  className="border-b border-r border-secondary-200 px-4 py-2 text-right last:border-r-0"
+                  key={`${rule}-rank`}
+                >
+                  順位
+                </th>,
+              ])}
+            </tr>
+          </thead>
+          <tbody>
+            {records.map((record) => (
+              <tr
+                className="border-b border-secondary-100 text-secondary-700 last:border-b-0 hover:bg-secondary-50"
+                key={record.season}
+              >
+                <th className="whitespace-nowrap border-r border-secondary-200 px-4 py-3 text-left font-medium text-secondary-900">
+                  {record.season}
+                </th>
+                {splatoonRules.flatMap((rule) => [
+                  <td
+                    className="border-r border-secondary-100 px-4 py-3 text-right tabular-nums"
+                    key={`${rule}-xp`}
+                  >
+                    {record.results[rule].xp.toFixed(1)}
+                  </td>,
+                  <td
+                    className="border-r border-secondary-200 px-4 py-3 text-right tabular-nums last:border-r-0"
+                    key={`${rule}-rank`}
+                  >
+                    {record.results[rule].rank}
+                  </td>,
+                ])}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="mt-2 text-xs text-secondary-500">
+        表は横にスクロールできます。
+      </p>
+    </section>
+  );
+};
+
+export default SplatoonRecordsTable;

--- a/frontend/src/components/hobbies/SplatoonRecordsTable.tsx
+++ b/frontend/src/components/hobbies/SplatoonRecordsTable.tsx
@@ -13,7 +13,7 @@ const SplatoonRecordsTable: React.FC<Props> = ({ records }) => {
         シーズン別記録
       </h2>
       <div className="overflow-x-auto rounded-lg border border-secondary-200">
-        <table className="min-w-[1080px] border-collapse bg-white text-sm">
+        <table className="w-full min-w-[800px] border-collapse bg-white text-sm">
           <thead>
             <tr className="bg-primary-50 text-primary-900">
               <th
@@ -77,9 +77,6 @@ const SplatoonRecordsTable: React.FC<Props> = ({ records }) => {
           </tbody>
         </table>
       </div>
-      <p className="mt-2 text-xs text-secondary-500">
-        表は横にスクロールできます。
-      </p>
     </section>
   );
 };

--- a/frontend/src/components/hobbies/SplatoonXpChart.client.test.tsx
+++ b/frontend/src/components/hobbies/SplatoonXpChart.client.test.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SplatoonXpChartClient from "@/components/hobbies/SplatoonXpChart.client";
+import type { SplatoonSeasonRecord } from "@/domains/hobbies/splatoon";
+
+vi.mock("chart.js", () => ({
+  CategoryScale: {},
+  Chart: { register: vi.fn() },
+  Legend: {},
+  LinearScale: {},
+  LineElement: {},
+  PointElement: {},
+  Tooltip: {},
+}));
+
+vi.mock("react-chartjs-2", () => ({
+  Line: ({ data }: { data: { datasets: { data: number[] }[] } }) => (
+    <div data-testid="chart-values">
+      {data.datasets.map((dataset) => dataset.data.join(",")).join("|")}
+    </div>
+  ),
+}));
+
+const records: readonly SplatoonSeasonRecord[] = [
+  {
+    season: "2022冬 Chill Season",
+    results: {
+      area: { xp: 2379.6, rank: 23560 },
+      tower: { xp: 2432.8, rank: 17973 },
+      rainmaker: { xp: 2565.3, rank: 5897 },
+      clamBlitz: { xp: 2447.6, rank: 13536 },
+    },
+  },
+];
+
+describe("SplatoonXpChartClient", () => {
+  beforeEach(() => {
+    render(<SplatoonXpChartClient records={records} />);
+  });
+
+  it("初期表示ではXPを選択し、4ルールのXPを表示する", () => {
+    expect(screen.getByRole("button", { name: "XP" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "順位" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(screen.getByTestId("chart-values")).toHaveTextContent(
+      "2379.6|2432.8|2565.3|2447.6",
+    );
+  });
+
+  it("順位を選択すると選択状態と4ルールの表示値を切り替える", () => {
+    fireEvent.click(screen.getByRole("button", { name: "順位" }));
+
+    expect(screen.getByRole("button", { name: "XP" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(screen.getByRole("button", { name: "順位" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByTestId("chart-values")).toHaveTextContent(
+      "20000|17973|5897|13536",
+    );
+    expect(
+      screen.getByText(
+        "20,000位より後ろの順位は、20,000位として表示しています。",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/hobbies/SplatoonXpChart.client.tsx
+++ b/frontend/src/components/hobbies/SplatoonXpChart.client.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import {
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LinearScale,
+  LineElement,
+  PointElement,
+  Tooltip,
+} from "chart.js";
+import type { ChartOptions, TooltipItem } from "chart.js";
+import { Line } from "react-chartjs-2";
+import type {
+  SplatoonRule,
+  SplatoonSeasonRecord,
+} from "@/domains/hobbies/splatoon";
+import { splatoonRuleLabels, splatoonRules } from "@/domains/hobbies/splatoon";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+);
+
+type Props = {
+  records: readonly SplatoonSeasonRecord[];
+};
+
+const chartColors: Record<SplatoonRule, string> = {
+  area: "#0f766e",
+  tower: "#ea580c",
+  rainmaker: "#2563eb",
+  clamBlitz: "#9333ea",
+};
+
+const SplatoonXpChartClient: React.FC<Props> = ({ records }) => {
+  const data = {
+    labels: records.map((record) => record.season),
+    datasets: splatoonRules.map((rule) => ({
+      label: splatoonRuleLabels[rule],
+      data: records.map((record) => record.results[rule].xp),
+      borderColor: chartColors[rule],
+      backgroundColor: chartColors[rule],
+      pointRadius: 3,
+      pointHoverRadius: 5,
+      tension: 0.2,
+    })),
+  };
+
+  const options: ChartOptions<"line"> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: {
+      mode: "index",
+      intersect: false,
+    },
+    plugins: {
+      legend: {
+        position: "top",
+      },
+      tooltip: {
+        callbacks: {
+          label: (context: TooltipItem<"line">) =>
+            `${context.dataset.label}: ${context.parsed.y?.toFixed(1) ?? "-"}`,
+        },
+      },
+    },
+    scales: {
+      x: {
+        ticks: {
+          maxRotation: 45,
+          minRotation: 45,
+        },
+      },
+      y: {
+        title: {
+          display: true,
+          text: "XP",
+        },
+      },
+    },
+  };
+
+  return (
+    <section className="mb-10">
+      <h2 className="mb-4 text-2xl font-semibold text-primary-900">
+        シーズンXP推移
+      </h2>
+      <div className="overflow-x-auto rounded-lg border border-secondary-100 bg-white p-4 shadow-sm">
+        <div className="h-[400px] min-w-[720px]">
+          <Line data={data} options={options} />
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default SplatoonXpChartClient;

--- a/frontend/src/components/hobbies/SplatoonXpChart.client.tsx
+++ b/frontend/src/components/hobbies/SplatoonXpChart.client.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   CategoryScale,
   Chart as ChartJS,
@@ -29,6 +29,10 @@ type Props = {
   records: readonly SplatoonSeasonRecord[];
 };
 
+type Metric = "xp" | "rank";
+
+const RANK_CHART_LIMIT = 20000;
+
 const chartColors: Record<SplatoonRule, string> = {
   area: "#0f766e",
   tower: "#ea580c",
@@ -37,11 +41,16 @@ const chartColors: Record<SplatoonRule, string> = {
 };
 
 const SplatoonXpChartClient: React.FC<Props> = ({ records }) => {
+  const [metric, setMetric] = useState<Metric>("xp");
+  const isRank = metric === "rank";
   const data = {
     labels: records.map((record) => record.season),
     datasets: splatoonRules.map((rule) => ({
       label: splatoonRuleLabels[rule],
-      data: records.map((record) => record.results[rule].xp),
+      data: records.map((record) => {
+        const value = record.results[rule][metric];
+        return isRank ? Math.min(value, RANK_CHART_LIMIT) : value;
+      }),
       borderColor: chartColors[rule],
       backgroundColor: chartColors[rule],
       pointRadius: 3,
@@ -63,8 +72,22 @@ const SplatoonXpChartClient: React.FC<Props> = ({ records }) => {
       },
       tooltip: {
         callbacks: {
-          label: (context: TooltipItem<"line">) =>
-            `${context.dataset.label}: ${context.parsed.y?.toFixed(1) ?? "-"}`,
+          label: (context: TooltipItem<"line">) => {
+            const value = context.parsed.y;
+            if (value == null) {
+              return `${context.dataset.label}: -`;
+            }
+
+            if (!isRank) {
+              return `${context.dataset.label}: ${value.toFixed(1)}`;
+            }
+
+            const rule = splatoonRules[context.datasetIndex];
+            const originalRank = records[context.dataIndex]?.results[rule].rank;
+            return originalRank > RANK_CHART_LIMIT
+              ? `${context.dataset.label}: 20,000位以下`
+              : `${context.dataset.label}: ${value.toLocaleString("ja-JP")}位`;
+          },
         },
       },
     },
@@ -76,24 +99,67 @@ const SplatoonXpChartClient: React.FC<Props> = ({ records }) => {
         },
       },
       y: {
+        reverse: isRank,
+        max: isRank ? RANK_CHART_LIMIT : undefined,
         title: {
           display: true,
-          text: "XP",
+          text: isRank ? "順位" : "XP",
         },
+        ticks: isRank
+          ? {
+              callback: (value) =>
+                Number(value) === RANK_CHART_LIMIT
+                  ? "20,000位以下"
+                  : `${Number(value).toLocaleString("ja-JP")}位`,
+            }
+          : undefined,
       },
     },
   };
 
   return (
     <section className="mb-10">
-      <h2 className="mb-4 text-2xl font-semibold text-primary-900">
-        シーズンXP推移
-      </h2>
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <h2 className="text-2xl font-semibold text-primary-900">
+          シーズン推移
+        </h2>
+        <div className="flex gap-2">
+          <button
+            aria-pressed={metric === "xp"}
+            className={`rounded-md px-4 py-2 text-sm font-semibold transition-colors ${
+              metric === "xp"
+                ? "bg-primary-600 text-white"
+                : "border border-secondary-200 bg-white text-secondary-700 hover:bg-secondary-50"
+            }`}
+            onClick={() => setMetric("xp")}
+            type="button"
+          >
+            XP
+          </button>
+          <button
+            aria-pressed={metric === "rank"}
+            className={`rounded-md px-4 py-2 text-sm font-semibold transition-colors ${
+              metric === "rank"
+                ? "bg-primary-600 text-white"
+                : "border border-secondary-200 bg-white text-secondary-700 hover:bg-secondary-50"
+            }`}
+            onClick={() => setMetric("rank")}
+            type="button"
+          >
+            順位
+          </button>
+        </div>
+      </div>
       <div className="overflow-x-auto rounded-lg border border-secondary-100 bg-white p-4 shadow-sm">
         <div className="h-[400px] min-w-[720px]">
           <Line data={data} options={options} />
         </div>
       </div>
+      {isRank && (
+        <p className="mt-2 text-xs text-secondary-500">
+          20,000位より後ろの順位は、20,000位として表示しています。
+        </p>
+      )}
     </section>
   );
 };

--- a/frontend/src/components/hobbies/SplatoonXpChart.tsx
+++ b/frontend/src/components/hobbies/SplatoonXpChart.tsx
@@ -38,7 +38,7 @@ const SplatoonXpChart: React.FC<Props> = (props) => {
     return (
       <section className="mb-10">
         <h2 className="mb-4 text-2xl font-semibold text-primary-900">
-          シーズンXP推移
+          シーズン推移
         </h2>
         <div className="rounded-lg border border-dashed border-secondary-200 bg-primary-50 p-4 text-center text-primary-500">
           ブラウザ環境でチャートを読み込み中です…

--- a/frontend/src/components/hobbies/SplatoonXpChart.tsx
+++ b/frontend/src/components/hobbies/SplatoonXpChart.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from "react";
+import type { SplatoonSeasonRecord } from "@/domains/hobbies/splatoon";
+
+type Props = {
+  records: readonly SplatoonSeasonRecord[];
+};
+
+type ClientChart = React.ComponentType<Props>;
+
+const SplatoonXpChart: React.FC<Props> = (props) => {
+  const [ClientComponent, setClientComponent] = useState<ClientChart | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    let mounted = true;
+
+    import("./SplatoonXpChart.client")
+      .then((module) => {
+        if (mounted) {
+          setClientComponent(() => module.default);
+        }
+      })
+      .catch((error) => {
+        console.error("Failed to load SplatoonXpChart.client", error);
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  if (!ClientComponent) {
+    return (
+      <section className="mb-10">
+        <h2 className="mb-4 text-2xl font-semibold text-primary-900">
+          シーズンXP推移
+        </h2>
+        <div className="rounded-lg border border-dashed border-secondary-200 bg-primary-50 p-4 text-center text-primary-500">
+          ブラウザ環境でチャートを読み込み中です…
+        </div>
+      </section>
+    );
+  }
+
+  return <ClientComponent {...props} />;
+};
+
+export default SplatoonXpChart;

--- a/frontend/src/components/hobbies/SplatoonXpChart.tsx
+++ b/frontend/src/components/hobbies/SplatoonXpChart.tsx
@@ -19,7 +19,7 @@ const SplatoonXpChart: React.FC<Props> = (props) => {
 
     let mounted = true;
 
-    import("./SplatoonXpChart.client")
+    import("@/components/hobbies/SplatoonXpChart.client")
       .then((module) => {
         if (mounted) {
           setClientComponent(() => module.default);

--- a/frontend/src/data/splatoon.ts
+++ b/frontend/src/data/splatoon.ts
@@ -1,0 +1,133 @@
+import type { SplatoonSeasonRecord } from "@/domains/hobbies/splatoon";
+
+export const splatoonSeasonRecords: readonly [
+  SplatoonSeasonRecord,
+  ...SplatoonSeasonRecord[],
+] = [
+  {
+    season: "2022冬 Chill Season",
+    results: {
+      area: { xp: 2379.6, rank: 23560 },
+      tower: { xp: 2432.8, rank: 17973 },
+      rainmaker: { xp: 2565.3, rank: 5897 },
+      clamBlitz: { xp: 2447.6, rank: 13536 },
+    },
+  },
+  {
+    season: "2023春 Fresh Season",
+    results: {
+      area: { xp: 2352.4, rank: 20726 },
+      tower: { xp: 2453.0, rank: 11390 },
+      rainmaker: { xp: 2386.1, rank: 17568 },
+      clamBlitz: { xp: 2615.2, rank: 2380 },
+    },
+  },
+  {
+    season: "2023夏 Sizzle Season",
+    results: {
+      area: { xp: 2500.3, rank: 6781 },
+      tower: { xp: 2418.2, rank: 12644 },
+      rainmaker: { xp: 2379.7, rank: 15682 },
+      clamBlitz: { xp: 2444.9, rank: 9146 },
+    },
+  },
+  {
+    season: "2023秋 Dizzle Season",
+    results: {
+      area: { xp: 2514.3, rank: 4448 },
+      tower: { xp: 2408.1, rank: 10385 },
+      rainmaker: { xp: 2442.0, rank: 7531 },
+      clamBlitz: { xp: 2249.3, rank: 23848 },
+    },
+  },
+  {
+    season: "2023冬 Chill Season",
+    results: {
+      area: { xp: 2564.0, rank: 9861 },
+      tower: { xp: 2072.6, rank: 86287 },
+      rainmaker: { xp: 2342.0, rank: 25878 },
+      clamBlitz: { xp: 2254.9, rank: 32522 },
+    },
+  },
+  {
+    season: "2024春 Fresh Season",
+    results: {
+      area: { xp: 2492.2, rank: 15450 },
+      tower: { xp: 2316.7, rank: 29441 },
+      rainmaker: { xp: 2493.2, rank: 12570 },
+      clamBlitz: { xp: 2331.0, rank: 20928 },
+    },
+  },
+  {
+    season: "2024夏 Sizzle Season",
+    results: {
+      area: { xp: 2511.5, rank: 13014 },
+      tower: { xp: 2630.1, rank: 4521 },
+      rainmaker: { xp: 2309.5, rank: 27102 },
+      clamBlitz: { xp: 2304.4, rank: 22161 },
+    },
+  },
+  {
+    season: "2024秋 Dizzle Season",
+    results: {
+      area: { xp: 2442.7, rank: 13892 },
+      tower: { xp: 2097.8, rank: 59669 },
+      rainmaker: { xp: 2240.7, rank: 40015 },
+      clamBlitz: { xp: 2315.8, rank: 17104 },
+    },
+  },
+  {
+    season: "2024冬 Chill Season",
+    results: {
+      area: { xp: 2566.0, rank: 6872 },
+      tower: { xp: 2404.1, rank: 13961 },
+      rainmaker: { xp: 2346.1, rank: 16802 },
+      clamBlitz: { xp: 2393.5, rank: 10910 },
+    },
+  },
+  {
+    season: "2025春 Fresh Season",
+    results: {
+      area: { xp: 2347.0, rank: 18314 },
+      tower: { xp: 2161.3, rank: 41424 },
+      rainmaker: { xp: 2310.8, rank: 19551 },
+      clamBlitz: { xp: 2564.1, rank: 4179 },
+    },
+  },
+  {
+    season: "2025夏 Sizzle Season",
+    results: {
+      area: { xp: 2447.2, rank: 12786 },
+      tower: { xp: 2322.1, rank: 20006 },
+      rainmaker: { xp: 2452.5, rank: 9983 },
+      clamBlitz: { xp: 2451.2, rank: 8051 },
+    },
+  },
+  {
+    season: "2025秋 Dizzle Season",
+    results: {
+      area: { xp: 2395.9, rank: 12410 },
+      tower: { xp: 2471.6, rank: 8178 },
+      rainmaker: { xp: 2232.9, rank: 22267 },
+      clamBlitz: { xp: 2412.5, rank: 7736 },
+    },
+  },
+  {
+    season: "2025冬 Chill Season",
+    results: {
+      area: { xp: 2356.6, rank: 16816 },
+      tower: { xp: 2301.4, rank: 20014 },
+      rainmaker: { xp: 2241.6, rank: 24576 },
+      clamBlitz: { xp: 2518.5, rank: 5315 },
+    },
+  },
+  {
+    season: "2026春 Fresh Season",
+    results: {
+      area: { xp: 2332.9, rank: 21281 },
+      tower: { xp: 2408.7, rank: 14399 },
+      rainmaker: { xp: 2379.6, rank: 15358 },
+      clamBlitz: { xp: 2249.9, rank: 23950 },
+    },
+  },
+];

--- a/frontend/src/domains/hobbies/splatoon.test.ts
+++ b/frontend/src/domains/hobbies/splatoon.test.ts
@@ -1,22 +1,77 @@
 import { describe, expect, it } from "vitest";
 import { splatoonSeasonRecords } from "@/data/splatoon";
-import { getSplatoonHighlights } from "@/domains/hobbies/splatoon";
+import {
+  buildSplatoonXpSummary,
+  getBestSplatoonRank,
+} from "@/domains/hobbies/splatoon";
 
-describe("getSplatoonHighlights", () => {
-  it("全シーズン・全ルールから歴代最高XPと最高順位を返す", () => {
-    const highlights = getSplatoonHighlights(splatoonSeasonRecords);
+describe("buildSplatoonXpSummary", () => {
+  it("全シーズンからルール別の歴代最高XPを返す", () => {
+    const summary = buildSplatoonXpSummary(splatoonSeasonRecords);
 
-    expect(highlights).toEqual({
-      highestXp: {
+    expect(summary.allTime).toEqual({
+      area: {
+        season: "2024冬 Chill Season",
+        rule: "area",
+        value: 2566.0,
+      },
+      tower: {
         season: "2024夏 Sizzle Season",
         rule: "tower",
         value: 2630.1,
       },
-      bestRank: {
+      rainmaker: {
+        season: "2022冬 Chill Season",
+        rule: "rainmaker",
+        value: 2565.3,
+      },
+      clamBlitz: {
         season: "2023春 Fresh Season",
         rule: "clamBlitz",
-        value: 2380,
+        value: 2615.2,
       },
+    });
+  });
+
+  it("年別にルール別の最高XPを返す", () => {
+    const summary = buildSplatoonXpSummary(splatoonSeasonRecords);
+
+    expect(summary.yearly[3]).toEqual({
+      year: 2025,
+      highestXpByRule: {
+        area: {
+          season: "2025夏 Sizzle Season",
+          rule: "area",
+          value: 2447.2,
+        },
+        tower: {
+          season: "2025秋 Dizzle Season",
+          rule: "tower",
+          value: 2471.6,
+        },
+        rainmaker: {
+          season: "2025夏 Sizzle Season",
+          rule: "rainmaker",
+          value: 2452.5,
+        },
+        clamBlitz: {
+          season: "2025春 Fresh Season",
+          rule: "clamBlitz",
+          value: 2564.1,
+        },
+      },
+    });
+  });
+});
+
+describe("getBestSplatoonRank", () => {
+  it("全シーズン・全ルールから最高順位を返す", () => {
+    const bestRank = getBestSplatoonRank(splatoonSeasonRecords);
+
+    expect(bestRank).toEqual({
+      season: "2023春 Fresh Season",
+      rule: "clamBlitz",
+      value: 2380,
     });
   });
 });

--- a/frontend/src/domains/hobbies/splatoon.test.ts
+++ b/frontend/src/domains/hobbies/splatoon.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { splatoonSeasonRecords } from "@/data/splatoon";
 import {
   buildSplatoonXpSummary,
   getBestSplatoonRank,
 } from "@/domains/hobbies/splatoon";
+import { splatoonSeasonRecords } from "@/data/splatoon";
 
 describe("buildSplatoonXpSummary", () => {
   it("全シーズンからルール別の歴代最高XPを返す", () => {

--- a/frontend/src/domains/hobbies/splatoon.test.ts
+++ b/frontend/src/domains/hobbies/splatoon.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { splatoonSeasonRecords } from "@/data/splatoon";
+import { getSplatoonHighlights } from "@/domains/hobbies/splatoon";
+
+describe("getSplatoonHighlights", () => {
+  it("全シーズン・全ルールから歴代最高XPと最高順位を返す", () => {
+    const highlights = getSplatoonHighlights(splatoonSeasonRecords);
+
+    expect(highlights).toEqual({
+      highestXp: {
+        season: "2024夏 Sizzle Season",
+        rule: "tower",
+        value: 2630.1,
+      },
+      bestRank: {
+        season: "2023春 Fresh Season",
+        rule: "clamBlitz",
+        value: 2380,
+      },
+    });
+  });
+});

--- a/frontend/src/domains/hobbies/splatoon.ts
+++ b/frontend/src/domains/hobbies/splatoon.ts
@@ -1,0 +1,69 @@
+export const splatoonRules = [
+  "area",
+  "tower",
+  "rainmaker",
+  "clamBlitz",
+] as const;
+
+export type SplatoonRule = (typeof splatoonRules)[number];
+
+export const splatoonRuleLabels: Record<SplatoonRule, string> = {
+  area: "エリア",
+  tower: "ヤグラ",
+  rainmaker: "ホコ",
+  clamBlitz: "アサリ",
+};
+
+export type SplatoonResult = {
+  xp: number;
+  rank: number;
+};
+
+export type SplatoonSeasonRecord = {
+  season: string;
+  results: Record<SplatoonRule, SplatoonResult>;
+};
+
+export type SplatoonHighlight = {
+  season: string;
+  rule: SplatoonRule;
+  value: number;
+};
+
+export type SplatoonHighlights = {
+  highestXp: SplatoonHighlight;
+  bestRank: SplatoonHighlight;
+};
+
+export const getSplatoonHighlights = (
+  records: readonly [SplatoonSeasonRecord, ...SplatoonSeasonRecord[]],
+): SplatoonHighlights => {
+  const firstRecord = records[0];
+  const firstRule = splatoonRules[0];
+  let highestXp: SplatoonHighlight = {
+    season: firstRecord.season,
+    rule: firstRule,
+    value: firstRecord.results[firstRule].xp,
+  };
+  let bestRank: SplatoonHighlight = {
+    season: firstRecord.season,
+    rule: firstRule,
+    value: firstRecord.results[firstRule].rank,
+  };
+
+  records.forEach((record) => {
+    splatoonRules.forEach((rule) => {
+      const result = record.results[rule];
+
+      if (result.xp > highestXp.value) {
+        highestXp = { season: record.season, rule, value: result.xp };
+      }
+
+      if (result.rank < bestRank.value) {
+        bestRank = { season: record.season, rule, value: result.rank };
+      }
+    });
+  });
+
+  return { highestXp, bestRank };
+};

--- a/frontend/src/domains/hobbies/splatoon.ts
+++ b/frontend/src/domains/hobbies/splatoon.ts
@@ -30,21 +30,89 @@ export type SplatoonHighlight = {
   value: number;
 };
 
-export type SplatoonHighlights = {
-  highestXp: SplatoonHighlight;
-  bestRank: SplatoonHighlight;
+export type SplatoonHighestXpByRule = Record<SplatoonRule, SplatoonHighlight>;
+
+export type SplatoonYearlyHighestXp = {
+  year: number;
+  highestXpByRule: SplatoonHighestXpByRule;
 };
 
-export const getSplatoonHighlights = (
+export type SplatoonXpSummary = {
+  allTime: SplatoonHighestXpByRule;
+  yearly: SplatoonYearlyHighestXp[];
+};
+
+const createHighestXpByRule = (
+  record: SplatoonSeasonRecord,
+): SplatoonHighestXpByRule => ({
+  area: { season: record.season, rule: "area", value: record.results.area.xp },
+  tower: {
+    season: record.season,
+    rule: "tower",
+    value: record.results.tower.xp,
+  },
+  rainmaker: {
+    season: record.season,
+    rule: "rainmaker",
+    value: record.results.rainmaker.xp,
+  },
+  clamBlitz: {
+    season: record.season,
+    rule: "clamBlitz",
+    value: record.results.clamBlitz.xp,
+  },
+});
+
+const updateHighestXpByRule = (
+  current: SplatoonHighestXpByRule,
+  record: SplatoonSeasonRecord,
+): void => {
+  splatoonRules.forEach((rule) => {
+    if (record.results[rule].xp > current[rule].value) {
+      current[rule] = {
+        season: record.season,
+        rule,
+        value: record.results[rule].xp,
+      };
+    }
+  });
+};
+
+export const getSplatoonRecordYear = (record: SplatoonSeasonRecord): number =>
+  Number.parseInt(record.season.slice(0, 4), 10);
+
+export const buildSplatoonXpSummary = (
   records: readonly [SplatoonSeasonRecord, ...SplatoonSeasonRecord[]],
-): SplatoonHighlights => {
+): SplatoonXpSummary => {
+  const firstRecord = records[0];
+  const allTime = createHighestXpByRule(firstRecord);
+  const highestXpByYear = new Map<number, SplatoonHighestXpByRule>();
+
+  records.forEach((record) => {
+    const year = getSplatoonRecordYear(record);
+    const yearlyHighestXp = highestXpByYear.get(year);
+
+    updateHighestXpByRule(allTime, record);
+    if (yearlyHighestXp == null) {
+      highestXpByYear.set(year, createHighestXpByRule(record));
+    } else {
+      updateHighestXpByRule(yearlyHighestXp, record);
+    }
+  });
+
+  return {
+    allTime,
+    yearly: [...highestXpByYear.entries()]
+      .sort(([left], [right]) => left - right)
+      .map(([year, highestXpByRule]) => ({ year, highestXpByRule })),
+  };
+};
+
+export const getBestSplatoonRank = (
+  records: readonly [SplatoonSeasonRecord, ...SplatoonSeasonRecord[]],
+): SplatoonHighlight => {
   const firstRecord = records[0];
   const firstRule = splatoonRules[0];
-  let highestXp: SplatoonHighlight = {
-    season: firstRecord.season,
-    rule: firstRule,
-    value: firstRecord.results[firstRule].xp,
-  };
   let bestRank: SplatoonHighlight = {
     season: firstRecord.season,
     rule: firstRule,
@@ -55,15 +123,11 @@ export const getSplatoonHighlights = (
     splatoonRules.forEach((rule) => {
       const result = record.results[rule];
 
-      if (result.xp > highestXp.value) {
-        highestXp = { season: record.season, rule, value: result.xp };
-      }
-
       if (result.rank < bestRank.value) {
         bestRank = { season: record.season, rule, value: result.rank };
       }
     });
   });
 
-  return { highestXp, bestRank };
+  return bestRank;
 };

--- a/frontend/src/pages/hobbies/+Head.tsx
+++ b/frontend/src/pages/hobbies/+Head.tsx
@@ -6,13 +6,13 @@ const Head: React.FC = () => {
       <title>趣味 | ara-ta3のページ</title>
       <meta
         name="description"
-        content="ara-ta3の趣味の記録。Splatoon 3のシーズン別Xマッチ最高XPと順位を掲載しています。"
+        content="ara-ta3が好きなことや、続けている遊びの記録をまとめています。"
       />
       <link rel="canonical" href="https://ara-ta3.github.io/hobbies/" />
       <meta property="og:title" content="趣味 | ara-ta3のページ" />
       <meta
         property="og:description"
-        content="ara-ta3の趣味の記録。Splatoon 3のシーズン別Xマッチ最高XPと順位を掲載しています。"
+        content="ara-ta3が好きなことや、続けている遊びの記録をまとめています。"
       />
       <meta property="og:type" content="website" />
       <meta property="og:url" content="https://ara-ta3.github.io/hobbies/" />

--- a/frontend/src/pages/hobbies/+Head.tsx
+++ b/frontend/src/pages/hobbies/+Head.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+const Head: React.FC = () => {
+  return (
+    <>
+      <title>趣味 | ara-ta3のページ</title>
+      <meta
+        name="description"
+        content="ara-ta3の趣味の記録。Splatoon 3のシーズン別Xマッチ最高XPと順位を掲載しています。"
+      />
+      <link rel="canonical" href="https://ara-ta3.github.io/hobbies/" />
+      <meta property="og:title" content="趣味 | ara-ta3のページ" />
+      <meta
+        property="og:description"
+        content="ara-ta3の趣味の記録。Splatoon 3のシーズン別Xマッチ最高XPと順位を掲載しています。"
+      />
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content="https://ara-ta3.github.io/hobbies/" />
+    </>
+  );
+};
+
+export default Head;

--- a/frontend/src/pages/hobbies/+Layout.tsx
+++ b/frontend/src/pages/hobbies/+Layout.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import Footer from "@/components/Footer";
+
+type Props = {
+  children: React.ReactNode;
+};
+
+const HobbiesLayout: React.FC<Props> = ({ children }) => {
+  return (
+    <div className="flex min-h-screen flex-col overflow-x-hidden">
+      <div className="flex grow justify-center px-4 py-4 sm:px-8">
+        <div className="flex w-full max-w-[1120px] flex-col">{children}</div>
+      </div>
+      <Footer />
+    </div>
+  );
+};
+
+export default HobbiesLayout;

--- a/frontend/src/pages/hobbies/+Page.tsx
+++ b/frontend/src/pages/hobbies/+Page.tsx
@@ -4,10 +4,14 @@ import SplatoonHighlights from "@/components/hobbies/SplatoonHighlights";
 import SplatoonRecordsTable from "@/components/hobbies/SplatoonRecordsTable";
 import SplatoonXpChart from "@/components/hobbies/SplatoonXpChart";
 import { splatoonSeasonRecords } from "@/data/splatoon";
-import { getSplatoonHighlights } from "@/domains/hobbies/splatoon";
+import {
+  buildSplatoonXpSummary,
+  getBestSplatoonRank,
+} from "@/domains/hobbies/splatoon";
 
 const HobbiesPage: React.FC = () => {
-  const highlights = getSplatoonHighlights(splatoonSeasonRecords);
+  const xpSummary = buildSplatoonXpSummary(splatoonSeasonRecords);
+  const bestRank = getBestSplatoonRank(splatoonSeasonRecords);
 
   return (
     <>
@@ -32,7 +36,7 @@ const HobbiesPage: React.FC = () => {
           </p>
         </div>
 
-        <SplatoonHighlights highlights={highlights} />
+        <SplatoonHighlights bestRank={bestRank} xpSummary={xpSummary} />
         <SplatoonXpChart records={splatoonSeasonRecords} />
         <SplatoonRecordsTable records={splatoonSeasonRecords} />
       </article>

--- a/frontend/src/pages/hobbies/+Page.tsx
+++ b/frontend/src/pages/hobbies/+Page.tsx
@@ -1,18 +1,7 @@
 import React from "react";
 import BreadcrumbWithSchema from "@/components/BreadcrumbWithSchema";
-import SplatoonHighlights from "@/components/hobbies/SplatoonHighlights";
-import SplatoonRecordsTable from "@/components/hobbies/SplatoonRecordsTable";
-import SplatoonXpChart from "@/components/hobbies/SplatoonXpChart";
-import {
-  buildSplatoonXpSummary,
-  getBestSplatoonRank,
-} from "@/domains/hobbies/splatoon";
-import { splatoonSeasonRecords } from "@/data/splatoon";
 
 const HobbiesPage: React.FC = () => {
-  const xpSummary = buildSplatoonXpSummary(splatoonSeasonRecords);
-  const bestRank = getBestSplatoonRank(splatoonSeasonRecords);
-
   return (
     <>
       <BreadcrumbWithSchema pathname="/hobbies/" />
@@ -23,23 +12,23 @@ const HobbiesPage: React.FC = () => {
         </p>
       </div>
 
-      <article>
-        <div className="mb-6">
+      <div className="grid gap-4 sm:grid-cols-2">
+        <a
+          className="group rounded-xl border border-primary-100 bg-white p-6 shadow-sm transition hover:border-primary-300 hover:shadow-md"
+          href="/hobbies/splatoon/"
+        >
           <p className="text-sm font-semibold uppercase tracking-wider text-primary-600">
             Game
           </p>
-          <h2 className="mt-1 text-3xl font-bold text-primary-900">
-            Splatoon 3
-          </h2>
-          <p className="mt-3 max-w-2xl leading-7 text-secondary-600">
-            Xマッチで遊んだ記録です。各シーズンの4ルール別の最高XPと順位を残しています。
+          <h2 className="mt-2 text-2xl font-bold text-primary-900">Splatoon</h2>
+          <p className="mt-3 leading-7 text-secondary-600">
+            Splatoon 3のXマッチで遊んだ、シーズン別の最高XPと順位の記録です。
           </p>
-        </div>
-
-        <SplatoonHighlights bestRank={bestRank} xpSummary={xpSummary} />
-        <SplatoonXpChart records={splatoonSeasonRecords} />
-        <SplatoonRecordsTable records={splatoonSeasonRecords} />
-      </article>
+          <p className="mt-4 text-sm font-semibold text-primary-600 group-hover:text-primary-700">
+            記録を見る →
+          </p>
+        </a>
+      </div>
     </>
   );
 };

--- a/frontend/src/pages/hobbies/+Page.tsx
+++ b/frontend/src/pages/hobbies/+Page.tsx
@@ -3,11 +3,11 @@ import BreadcrumbWithSchema from "@/components/BreadcrumbWithSchema";
 import SplatoonHighlights from "@/components/hobbies/SplatoonHighlights";
 import SplatoonRecordsTable from "@/components/hobbies/SplatoonRecordsTable";
 import SplatoonXpChart from "@/components/hobbies/SplatoonXpChart";
-import { splatoonSeasonRecords } from "@/data/splatoon";
 import {
   buildSplatoonXpSummary,
   getBestSplatoonRank,
 } from "@/domains/hobbies/splatoon";
+import { splatoonSeasonRecords } from "@/data/splatoon";
 
 const HobbiesPage: React.FC = () => {
   const xpSummary = buildSplatoonXpSummary(splatoonSeasonRecords);

--- a/frontend/src/pages/hobbies/+Page.tsx
+++ b/frontend/src/pages/hobbies/+Page.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import BreadcrumbWithSchema from "@/components/BreadcrumbWithSchema";
+import SplatoonHighlights from "@/components/hobbies/SplatoonHighlights";
+import SplatoonRecordsTable from "@/components/hobbies/SplatoonRecordsTable";
+import SplatoonXpChart from "@/components/hobbies/SplatoonXpChart";
+import { splatoonSeasonRecords } from "@/data/splatoon";
+import { getSplatoonHighlights } from "@/domains/hobbies/splatoon";
+
+const HobbiesPage: React.FC = () => {
+  const highlights = getSplatoonHighlights(splatoonSeasonRecords);
+
+  return (
+    <>
+      <BreadcrumbWithSchema pathname="/hobbies/" />
+      <div className="mb-10 text-center">
+        <h1 className="text-3xl font-bold text-primary-900">趣味</h1>
+        <p className="mt-2 text-primary-500">
+          好きなことや、続けている遊びの記録をまとめています
+        </p>
+      </div>
+
+      <article>
+        <div className="mb-6">
+          <p className="text-sm font-semibold uppercase tracking-wider text-primary-600">
+            Game
+          </p>
+          <h2 className="mt-1 text-3xl font-bold text-primary-900">
+            Splatoon 3
+          </h2>
+          <p className="mt-3 max-w-2xl leading-7 text-secondary-600">
+            Xマッチで遊んだ記録です。各シーズンの4ルール別の最高XPと順位を残しています。
+          </p>
+        </div>
+
+        <SplatoonHighlights highlights={highlights} />
+        <SplatoonXpChart records={splatoonSeasonRecords} />
+        <SplatoonRecordsTable records={splatoonSeasonRecords} />
+      </article>
+    </>
+  );
+};
+
+export default HobbiesPage;

--- a/frontend/src/pages/hobbies/Page.test.tsx
+++ b/frontend/src/pages/hobbies/Page.test.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import HobbiesPage from "@/pages/hobbies/+Page";
+
+describe("HobbiesPage", () => {
+  it("Splatoonの詳細ページへの導線を表示する", () => {
+    render(<HobbiesPage />);
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("趣味");
+    expect(screen.getByRole("link", { name: /Splatoon/ })).toHaveAttribute(
+      "href",
+      "/hobbies/splatoon/",
+    );
+  });
+});

--- a/frontend/src/pages/hobbies/splatoon/+Head.tsx
+++ b/frontend/src/pages/hobbies/splatoon/+Head.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+const Head: React.FC = () => {
+  return (
+    <>
+      <title>Splatoon | 趣味 | ara-ta3のページ</title>
+      <meta
+        name="description"
+        content="ara-ta3のSplatoonの記録。Splatoon 3のシーズン別Xマッチ最高XPと順位を掲載しています。"
+      />
+      <link
+        rel="canonical"
+        href="https://ara-ta3.github.io/hobbies/splatoon/"
+      />
+      <meta property="og:title" content="Splatoon | 趣味 | ara-ta3のページ" />
+      <meta
+        property="og:description"
+        content="ara-ta3のSplatoonの記録。Splatoon 3のシーズン別Xマッチ最高XPと順位を掲載しています。"
+      />
+      <meta property="og:type" content="website" />
+      <meta
+        property="og:url"
+        content="https://ara-ta3.github.io/hobbies/splatoon/"
+      />
+    </>
+  );
+};
+
+export default Head;

--- a/frontend/src/pages/hobbies/splatoon/+Page.tsx
+++ b/frontend/src/pages/hobbies/splatoon/+Page.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import BreadcrumbWithSchema from "@/components/BreadcrumbWithSchema";
+import SplatoonHighlights from "@/components/hobbies/SplatoonHighlights";
+import SplatoonRecordsTable from "@/components/hobbies/SplatoonRecordsTable";
+import SplatoonXpChart from "@/components/hobbies/SplatoonXpChart";
+import {
+  buildSplatoonXpSummary,
+  getBestSplatoonRank,
+} from "@/domains/hobbies/splatoon";
+import { splatoonSeasonRecords } from "@/data/splatoon";
+
+const SplatoonPage: React.FC = () => {
+  const xpSummary = buildSplatoonXpSummary(splatoonSeasonRecords);
+  const bestRank = getBestSplatoonRank(splatoonSeasonRecords);
+
+  return (
+    <>
+      <BreadcrumbWithSchema pathname="/hobbies/splatoon/" />
+      <div className="mb-10 text-center">
+        <h1 className="text-3xl font-bold text-primary-900">Splatoon</h1>
+        <p className="mt-2 text-primary-500">
+          Splatoonシリーズで遊んだ記録をまとめています
+        </p>
+      </div>
+
+      <article>
+        <div className="mb-6">
+          <p className="text-sm font-semibold uppercase tracking-wider text-primary-600">
+            Game Record
+          </p>
+          <h2 className="mt-1 text-3xl font-bold text-primary-900">
+            Splatoon 3
+          </h2>
+          <p className="mt-3 max-w-2xl leading-7 text-secondary-600">
+            Xマッチで遊んだ記録です。各シーズンの4ルール別の最高XPと順位を残しています。
+          </p>
+        </div>
+
+        <SplatoonHighlights bestRank={bestRank} xpSummary={xpSummary} />
+        <SplatoonXpChart records={splatoonSeasonRecords} />
+        <SplatoonRecordsTable records={splatoonSeasonRecords} />
+      </article>
+    </>
+  );
+};
+
+export default SplatoonPage;

--- a/frontend/src/utils/breadcrumbConfig.ts
+++ b/frontend/src/utils/breadcrumbConfig.ts
@@ -19,6 +19,10 @@ export const breadcrumbConfig: Record<string, BreadcrumbConfig> = {
     name: "スライド一覧",
     parent: "/",
   },
+  "/hobbies/": {
+    name: "趣味",
+    parent: "/",
+  },
   "/electricity/": {
     name: "電気代比較ツール",
     parent: "/",

--- a/frontend/src/utils/breadcrumbConfig.ts
+++ b/frontend/src/utils/breadcrumbConfig.ts
@@ -23,6 +23,10 @@ export const breadcrumbConfig: Record<string, BreadcrumbConfig> = {
     name: "趣味",
     parent: "/",
   },
+  "/hobbies/splatoon/": {
+    name: "Splatoon",
+    parent: "/hobbies/",
+  },
   "/electricity/": {
     name: "電気代比較ツール",
     parent: "/",


### PR DESCRIPTION
## issues

関連するissueはありません。

## 概要

- 趣味ページを追加し、Splatoon 3のシーズン別Xマッチ記録を掲載
- 最高XP・最高順位の表示、XP推移チャート、ルール別記録テーブルを実装
- ヘッダーナビゲーションとサイトマップに趣味ページを追加

## 関連リンク

特になし。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 「趣味」ページを追加し、Splatoon 3のシーズン別記録、ルール別最高XP、最高順位を確認できるようになりました。
  * XPと順位を切り替えられる折れ線グラフを追加しました。
  * シーズン別記録を表形式で表示します。
  * ヘッダーメニューとサイトマップに「趣味」ページを追加しました。

* **改善**
  * 「趣味」ページのパンくず、メタ情報、レイアウトを整備しました。

* **テスト**
  * ハイライト、グラフ、集計結果の表示と切り替えを検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->