### PR TITLE
開発サーバーの停止手順とCI説明を安全にする

### DIFF
--- a/.agents/skills/testing-frontend/SKILL.md
+++ b/.agents/skills/testing-frontend/SKILL.md
@@ -29,11 +29,12 @@ make build/frontend
 # 2. スライドのカードからリンクされる /slides/<slug>.html もテストするなら marp も生成しておく
 make marp
 
-# 3. dev サーバーを停止して serve に切り替え
-pkill -f 'vike dev' 2>/dev/null
-make server/dist > /tmp/serve.log 2>&1 &
+# 3. make server を起動した端末で Ctrl-C を押し、dev サーバーを停止する
 
-# 4. 動作確認
+# 4. ビルド成果物の配信サーバーを起動する
+make server/dist
+
+# 5. 別の端末から動作確認
 curl -sS --max-time 10 -w 'HTTP %{http_code}\n' http://localhost:3000/
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 - `ara-ta3.github.io` で公開する、ポートフォリオ・ブログ・登壇資料を含む個人サイト。
 - フロントエンドは Vike + React + TypeScript による SSG。Tailwind CSS と Flowbite React を使用する。
 - バックエンドは Scala + ZIO + zio-http。
-- GitHub Actions でテスト・ビルドを行い、`master` を GitHub Pages へデプロイする。
+- GitHub Actions でテスト・ビルドを行い、GitHub Pages へデプロイする。
 
 ## プロジェクト構成
 


### PR DESCRIPTION
## 概要

PR #568 のレビュー指摘をマージ後のコードに対して再検証し、現在も有効な2件をフォローアップします。
開発サーバーの安全な停止手順と、CI設定の正本を `.github/workflows/` に保つためのドキュメント整理を行います。

## 変更内容

- `pkill -f 'vike dev'` を削除し、`make server` を起動した端末で Ctrl-C してから `make server/dist` へ切り替える手順に変更しました。
- `AGENTS.md` からデプロイ元ブランチ名を削除し、GitHub Actions の具体的な設定を重複して持たない記述にしました。
- READMEの見出し形式に関する指摘は、リポジトリにmarkdownlintの設定・実行入口がなく、指摘箇所だけの変更では文書全体の統一性が改善しないため、このPRには含めていません。

## 挙動・影響

- サイトの実装、ビルド、デプロイの挙動は変更しません。
- 手順に従った際、別プロジェクトで動作しているVike開発サーバーを誤って停止しなくなります。

## 動作確認

- `git diff --check`: 差分に空白エラーがないことを確認しました。
- `make lint`: ESLintが成功することを確認しました。

## 関連

- [PR #568](https://github.com/ara-ta3/ara-ta3.github.io/pull/568): 本PRで再検証したレビュー指摘の元PRです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * フロントエンドの動作確認手順を更新し、開発サーバーの停止・起動方法をより明確にしました。
  * 別の端末から動作確認を行う手順を追加しました。
  * GitHub Pages のデプロイ手順における対象ブランチの指定を見直しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->