### PR TITLE
記事一覧で年間サマリーと月別推移を先に表示

### DIFF
--- a/frontend/src/pages/articles/+Page.tsx
+++ b/frontend/src/pages/articles/+Page.tsx
@@ -20,9 +20,9 @@ const ArticlesPage: React.FC = () => {
           はてなブログ・Zenn・企業ブログ で投稿した記事をまとめて表示しています
         </p>
       </div>
-      <PopularArticles articles={popularArticles} />
       <YearlyArticleSummary stats={yearlyStats} />
       <MonthlyArticleChart stats={monthlyStats} />
+      <PopularArticles articles={popularArticles} />
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         {articles.map((article) => (
           <ArticleCard key={article.link} article={article} />


### PR DESCRIPTION
## 概要

記事一覧ページで、記事の投稿状況を把握しやすくするため、年間サマリーと月別推移を記事カードより先に表示します。

## 変更内容

- 表示順を「年間サマリー → 月別推移 → よく読まれた記事 → 記事一覧」に変更
- 集計内容や記事データ、各コンポーネントの挙動は変更なし

## 動作確認

- `make lint` ✅
- `make test` ✅（56 tests）
- `make build/frontend` ✅
- 生成された記事一覧HTMLの見出し順を確認 ✅